### PR TITLE
Add qmake project file

### DIFF
--- a/qtphy.pro
+++ b/qtphy.pro
@@ -1,0 +1,19 @@
+TEMPLATE = app
+TARGET = qtphy
+
+QT += qml quick dbus
+
+SOURCES += \
+    src/main.cpp \
+    src/device_info.cpp \
+    src/rauc.cpp
+
+HEADERS += \
+    src/device_info.hpp \
+    src/rauc.hpp
+
+RESOURCES += \
+    resources/resources.qrc
+
+target.path = $$(bindir)/qtphy
+INSTALLS += target


### PR DESCRIPTION
Add a project file to support building with qmake, as an alternative to the Meson Build System where the latter is not fully supported or available.