### PR TITLE
qtphy.pro: Install binary directly to bindir

### DIFF
--- a/qtphy.pro
+++ b/qtphy.pro
@@ -15,5 +15,5 @@ HEADERS += \
 RESOURCES += \
     resources/resources.qrc
 
-target.path = $$(bindir)/qtphy
+target.path = $$(bindir)
 INSTALLS += target


### PR DESCRIPTION
Install the built binary directly to bindir instead of a subdirectory of same name.