### PR TITLE
meson.build: Require version 0.63

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@ project(
   'qtphy', 'cpp',
   version : '0.1.0',
   license : 'MIT',
-  meson_version : '>=0.60.0'
+  meson_version : '>=0.63.0'
 )
 
 qt6 = import('qt6')


### PR DESCRIPTION
Require Meson Build version 0.63 or later, as previous versions are unable to find dependencies of Qt6.1 and later.