### PR TITLE
resources: pages: use standard image path

### DIFF
--- a/resources/pages/image_viewer.qml
+++ b/resources/pages/image_viewer.qml
@@ -33,7 +33,7 @@ Page {
         id: folderModel
         nameFilters: ["*.jpg"]
         showDirs: false
-        folder: "file:///home/schwan/downloads/qtphy-pictures"
+        folder: "file:///usr/share/qtphy/images"
     }
 
     Component {

--- a/resources/pages/image_viewer.qml
+++ b/resources/pages/image_viewer.qml
@@ -31,7 +31,7 @@ Page {
 
     FolderListModel {
         id: folderModel
-        nameFilters: ["*.jpg"]
+        nameFilters: ["*.jpg", "*.JPG", "*.jpeg", "*.png", "*.webp", "*.bmp"]
         showDirs: false
         folder: "file:///usr/share/qtphy/images"
     }


### PR DESCRIPTION
Use image path that feels more natural for use with target devices. Now all images that needs to be displayed should be put inside: "/usr/share/qtphy/images/" folder.