### PR TITLE
resources: main: Correctly scale and wrap text in slider items

### DIFF
--- a/resources/main.qml
+++ b/resources/main.qml
@@ -136,31 +136,29 @@ ApplicationWindow {
                     anchors.fill: parent
 
                     ColumnLayout {
-                        spacing: PhyTheme.marginBig
-                        Layout.margins: PhyTheme.marginBig
+                        spacing: PhyTheme.marginRegular
+                        Layout.margins: PhyTheme.marginRegular
+                        Layout.fillWidth: true
 
                         Label {
                             text: icon
                             color: PhyTheme.teal1
                             font.family: icons.font.family
-                            font.pointSize: Math.max(0.05 * parent.width, 48)
+                            font.pointSize: icons.font.pointSize * 3
                             Layout.alignment: Qt.AlignHCenter
                         }
                         Label {
-                            text: name
-                            elide: Text.ElideRight
+                            text: "<h2>" + name + "</h2>"
+                            wrapMode: Text.WordWrap
                             color: PhyTheme.white
-                            font.pointSize: Math.max(0.015 * parent.width, 24)
-                            Layout.alignment: Qt.AlignHCenter
                             Layout.fillWidth: true
+                            horizontalAlignment: Text.AlignHCenter
                         }
                         Label {
                             text: description
                             elide: Text.ElideRight
                             wrapMode: Text.WordWrap
-                            color: PhyTheme.gray1
-                            font.weight: Font.Light
-                            font.pointSize: Math.max(0.01 * parent.width, 20)
+                            color: PhyTheme.gray2
                             Layout.fillHeight: true
                             Layout.fillWidth: true
                         }

--- a/resources/main.qml
+++ b/resources/main.qml
@@ -12,8 +12,8 @@ import PhyTheme 1.0
 ApplicationWindow {
     visible: true
     visibility: Window.FullScreen
-    width: 1280
-    height: 800
+    width: 640
+    height: 480
 
     property int itemAngle: 55
     property int itemSize: 0.4 * width

--- a/resources/main.qml
+++ b/resources/main.qml
@@ -29,7 +29,7 @@ ApplicationWindow {
 
     FontLoader {
         id: icons
-        source: "qrc:/fonts/MaterialIcons-Regular.ttf"
+        source: "qrc:///fonts/MaterialIcons-Regular.ttf"
     }
     ListModel {
         id: pageModel


### PR DESCRIPTION
Correctly scale and wrap the text in the main page's slider items. Also prevent the items' header text from being elided. This text should be always readable. Only the longer description text may be elided.

Shrink the default window size to 640x480 pixels allowing smaller displays to correctly display the application.