### PR TITLE
resources: pages: multimedia: Set default video and add toolbar subtitle

### DIFF
--- a/resources/controls/PhyToolBar.qml
+++ b/resources/controls/PhyToolBar.qml
@@ -10,6 +10,7 @@ import PhyTheme 1.0
 
 ToolBar {
     property string title: ""
+    property string subTitle: ""
     property alias buttonBack: buttonBack
     property alias buttonMenu: buttonMenu
 
@@ -21,24 +22,40 @@ ToolBar {
             text: PhyTheme.iconFont.arrowLeft
             font.family: icons.font.family
             flat: true
-            leftPadding: PhyTheme.marginRegular
-            rightPadding: PhyTheme.marginRegular
+            leftPadding: PhyTheme.marginBig
+            rightPadding: PhyTheme.marginBig
+            topPadding: PhyTheme.marginRegular
+            bottomPadding: PhyTheme.marginRegular
         }
-        Label {
-            text: title
-            elide: Label.ElideRight
-            horizontalAlignment: Qt.AlignHCenter
-            verticalAlignment: Qt.AlignVCenter
-            Layout.fillWidth: true
+        ColumnLayout {
+            Layout.alignment: Qt.AlignVCenter
+
+            Label {
+                text: "<b>" + title + "</b>"
+                elide: Text.ElideRight
+                Layout.alignment: Qt.AlignHCenter
+            }
+            Label {
+                text: subTitle
+                color: PhyTheme.gray4
+                visible: text !== ""
+                elide: Text.ElideLeft
+                scale: 0.8
+                Layout.fillWidth: true
+                Layout.alignment: Qt.AlignHCenter
+            }
         }
         ToolButton {
             id: buttonMenu
+            Layout.fillWidth: false
             text: PhyTheme.iconFont.list
             font.family: icons.font.family
             flat: true
             visible: false
-            leftPadding: PhyTheme.marginRegular
-            rightPadding: PhyTheme.marginRegular
+            leftPadding: PhyTheme.marginBig
+            rightPadding: PhyTheme.marginBig
+            topPadding: PhyTheme.marginRegular
+            bottomPadding: PhyTheme.marginRegular
         }
     }
 }

--- a/resources/pages/multimedia.qml
+++ b/resources/pages/multimedia.qml
@@ -95,6 +95,7 @@ Page {
 
     PhyFileDialog {
         id: fileDialog
+        selectedFile: "file:///usr/share/qtphy/videos/caminandes_3_llamigos_720p_vp9.webm"
         nameFilters: ["*.webm", "*.mp4"]
     }
 }

--- a/resources/pages/multimedia.qml
+++ b/resources/pages/multimedia.qml
@@ -15,8 +15,8 @@ Page {
         id: header
         title: "Multimedia"
         buttonBack.onClicked: {
-            stack.pop()
             video.pause()
+            stack.pop()
         }
         buttonMenu {
             text: PhyTheme.iconFont.folderOpen

--- a/resources/pages/multimedia.qml
+++ b/resources/pages/multimedia.qml
@@ -14,6 +14,7 @@ Page {
     header: PhyToolBar {
         id: header
         title: "Multimedia"
+        subTitle: !fileDialog.selectedFile ? "" : fileDialog.selectedFile.toString()
         buttonBack.onClicked: {
             video.pause()
             stack.pop()

--- a/resources/pages/multimedia.qml
+++ b/resources/pages/multimedia.qml
@@ -70,27 +70,6 @@ Page {
         id: video
         anchors.fill: parent
         source: fileDialog.selectedFile
-
-        MouseArea {
-            anchors.fill: parent
-            onClicked: video.playbackState != MediaPlayer.PlayingState ?
-                       video.play() : video.pause()
-        }
-        Label {
-            text: PhyTheme.iconFont.pause
-            font.family: icons.font.family
-            anchors.centerIn: parent
-            color: PhyTheme.white
-            scale: 4
-            visible: video.playbackState === MediaPlayer.PausedState
-        }
-        Label {
-            text: !fileDialog.selectedFile ? "No video opened. Select a file first!" :
-                                             fileDialog.selectedFile.toString().replace("file://", "")
-            anchors.horizontalCenter: parent.horizontalCenter
-            anchors.bottom: parent.bottom
-            color: PhyTheme.white
-        }
     }
 
     PhyFileDialog {


### PR DESCRIPTION
Set the default video path to the provided example video.

Allow placing a subtitle in the toolbar. While at it, adjust the padding of the toolbar to be less wasteful. Set the toolbar's subtitle to the currently selected video path.