### PR TITLE
Wip/andrej.picej@norik.com/qmlsink

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -7,19 +7,26 @@ project(
 
 qt6 = import('qt6')
 qt6_dep = dependency('qt6', modules : ['Core', 'Qml', 'Quick', 'Gui', 'DBus', 'Multimedia'])
-gst_dep = dependency('gstreamer-1.0', fallback : ['gstreamer', 'gst_dep'])
+exec_dep = [qt6_dep]
 
 headers = [
   'src/device_info.hpp',
-  'src/rauc.hpp',
-  'src/multimedia_qmlsink.hpp'
+  'src/rauc.hpp'
 ]
 src = [
   'src/main.cpp',
   'src/device_info.cpp',
-  'src/rauc.cpp',
-  'src/multimedia_qmlsink.cpp'
+  'src/rauc.cpp'
 ]
+
+qmlsink_option = get_option('qmlsink')
+if qmlsink_option.enabled()
+    gst_dep = dependency('gstreamer-1.0')
+    exec_dep += [gst_dep]
+    add_project_arguments('-DQML_SINK', language : 'cpp')
+    headers += ['src/multimedia_qmlsink.hpp']
+    src += ['src/multimedia_qmlsink.cpp']
+endif
 
 inc = include_directories('src')
 moc = qt6.compile_moc(
@@ -35,6 +42,6 @@ executable(
   meson.project_name(),
   sources : [src, res, moc],
   include_directories : inc,
-  dependencies : [qt6_dep, gst_dep],
+  dependencies : exec_dep,
   install : true
 )

--- a/meson.build
+++ b/meson.build
@@ -7,15 +7,18 @@ project(
 
 qt6 = import('qt6')
 qt6_dep = dependency('qt6', modules : ['Core', 'Qml', 'Quick', 'Gui', 'DBus', 'Multimedia'])
+gst_dep = dependency('gstreamer-1.0', fallback : ['gstreamer', 'gst_dep'])
 
 headers = [
   'src/device_info.hpp',
-  'src/rauc.hpp'
+  'src/rauc.hpp',
+  'src/multimedia_qmlsink.hpp'
 ]
 src = [
   'src/main.cpp',
   'src/device_info.cpp',
-  'src/rauc.cpp'
+  'src/rauc.cpp',
+  'src/multimedia_qmlsink.cpp'
 ]
 
 inc = include_directories('src')
@@ -32,6 +35,6 @@ executable(
   meson.project_name(),
   sources : [src, res, moc],
   include_directories : inc,
-  dependencies : qt6_dep,
+  dependencies : [qt6_dep, gst_dep],
   install : true
 )

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,1 @@
+option('qmlsink', type : 'feature', value : 'auto', description : 'Qt6 QML video sink plugin')

--- a/qtphy.pro
+++ b/qtphy.pro
@@ -3,19 +3,20 @@ TARGET = qtphy
 
 QT += qml quick dbus
 
-PKGCONFIG = \
-    gstreamer-1.0
-
 SOURCES += \
     src/main.cpp \
     src/device_info.cpp \
-    src/multimedia_qmlsink.cpp \
     src/rauc.cpp
 
 HEADERS += \
     src/device_info.hpp \
-    src/multimedia_qmlsink.hpp \
     src/rauc.hpp
+
+qmlsink {
+    PKGCONFIG = gstreamer-1.0
+    SOURCES += src/multimedia_qmlsink.cpp
+    HEADERS += src/multimedia_qmlsink.hpp
+}
 
 RESOURCES += \
     resources/resources.qrc

--- a/qtphy.pro
+++ b/qtphy.pro
@@ -3,13 +3,18 @@ TARGET = qtphy
 
 QT += qml quick dbus
 
+PKGCONFIG = \
+    gstreamer-1.0
+
 SOURCES += \
     src/main.cpp \
     src/device_info.cpp \
+    src/multimedia_qmlsink.cpp \
     src/rauc.cpp
 
 HEADERS += \
     src/device_info.hpp \
+    src/multimedia_qmlsink.hpp \
     src/rauc.hpp
 
 RESOURCES += \

--- a/resources/main.qml
+++ b/resources/main.qml
@@ -38,6 +38,12 @@ ApplicationWindow {
             page: "qrc:///pages/multimedia.qml"
         }
         ListElement {
+            icon: "\ue8da"
+            name: "Multimedia GST"
+            description: "Play movies with hardware acceleration"
+            page: "qrc:///pages/multimedia_qmlsink.qml"
+        }
+        ListElement {
             icon: "\ue8d7"
             name: "RAUC – Update Client"
             description: "View the RAUC status and update your device with new software"

--- a/resources/main.qml
+++ b/resources/main.qml
@@ -38,12 +38,6 @@ ApplicationWindow {
             page: "qrc:///pages/multimedia.qml"
         }
         ListElement {
-            icon: "\ue8da"
-            name: "Multimedia GST"
-            description: "Play movies with hardware acceleration"
-            page: "qrc:///pages/multimedia_qmlsink.qml"
-        }
-        ListElement {
             icon: "\ue8d7"
             name: "RAUC – Update Client"
             description: "View the RAUC status and update your device with new software"
@@ -184,6 +178,10 @@ ApplicationWindow {
                 for (var i = 0; i < pageModel.count; i++) {
                     var entry = pageModel.get(i);
                     if (enabledPages.indexOf(entry.name) >= 0) {
+                        // Workaround as we can not use variables for ListElement property values.
+                        if(entry.name === "Multimedia") {
+                            entry.page = "qrc:///pages/" + multimediaPage
+                        }
                         items.insert(entry, "configured");
                     }
                 }

--- a/resources/pages/multimedia_qmlsink.qml
+++ b/resources/pages/multimedia_qmlsink.qml
@@ -1,0 +1,127 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2021 PHYTEC Messtechnik GmbH
+ */
+
+import QtQuick 2.0
+import QtQuick.Controls 2.0
+import QtQuick.Layouts 1.0
+import QtMultimedia 5.15
+import PhyTheme 1.0
+import "../controls"
+
+import org.freedesktop.gstreamer.Qt6GLVideoItem 1.0
+
+Page {
+    header: PhyToolBar {
+        id: header
+        title: "Multimedia GST"
+        subTitle: !fileDialog.selectedFile ? "" : fileDialog.selectedFile.toString()
+        buttonBack.onClicked: {
+            multimediaGST.pause()
+            stack.pop()
+        }
+        buttonMenu {
+            text: PhyTheme.iconFont.folderOpen
+            font.family: icons.font.family
+            onClicked: fileDialog.visible = true
+            visible: true
+        }
+    }
+    background: Rectangle {
+        color: PhyTheme.black
+    }
+    footer: ToolBar {
+        ColumnLayout {
+            anchors.fill: parent
+
+            RowLayout {
+                Layout.alignment: Qt.AlignVCenter | Qt.AlignHCenter
+
+                ToolButton {
+                    text: PhyTheme.iconFont.play
+                    font.family: icons.font.family
+                    onClicked: multimediaGST.play()
+                }
+                ToolButton {
+                    text: PhyTheme.iconFont.pause
+                    font.family: icons.font.family
+                    onClicked: multimediaGST.pause()
+                }
+                ToolButton {
+                    text: PhyTheme.iconFont.skipBack
+                    font.family: icons.font.family
+                    onClicked: multimediaGST.seek(slider.value - 5000)
+                }
+                ToolButton {
+                    text: PhyTheme.iconFont.skipForward
+                    font.family: icons.font.family
+                    onClicked: multimediaGST.seek(slider.value + 5000)
+                }
+                Label {
+                    id: video_time_cur
+                    text: "00:00"
+                }
+                Slider {
+                    id: slider
+                    Layout.fillWidth: true
+                    from: 0
+                    to: 100
+                    value: 0
+                    onMoved: multimediaGST.seek(value)
+                    onPressedChanged: {
+                        if (pressed)
+                            multimediaGST.positionStop()
+                        else
+                            multimediaGST.positionStart()
+                    }
+                }
+                Label {
+                    id: video_time_len
+                    text: "00:00"
+                }
+                Connections {
+                    target: multimediaGST
+                    function onDurationChanged(len) {
+                        slider.to = len
+                        if (len >= 3600000) {
+                            video_time_len.text = new Date(len).toLocaleTimeString(Qt.locale(), "hh:" + "mm:" + "ss")
+                        } else {
+                            video_time_len.text = new Date(len).toLocaleTimeString(Qt.locale(), "mm:" + "ss")
+                        }
+                    }
+                    function onPositionChanged(pos) {
+                        slider.value = pos
+                        if (slider.to >= 3600000) {
+                            video_time_cur.text = new Date(pos).toLocaleTimeString(Qt.locale(), "hh:" + "mm:" + "ss")
+                        } else {
+                            video_time_cur.text = new Date(pos).toLocaleTimeString(Qt.locale(), "mm:" + "ss")
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Item {
+        anchors.fill: parent
+
+        GstGLQt6VideoItem {
+            id: video
+            objectName: "videoItem"
+            anchors.centerIn: parent
+            width: parent.width
+            height: parent.height
+            Component.onCompleted:
+                multimediaGST.setupNewPipeline(fileDialog.selectedFile)
+        }
+    }
+
+    PhyFileDialog {
+        id: fileDialog
+        selectedFile: "file:///usr/share/qtphy/videos/caminandes_3_llamigos_720p_vp9.webm"
+        nameFilters: ["*.webm", "*.mp4"]
+        onSelectedFileChanged:
+            multimediaGST.setupNewPipeline(fileDialog.selectedFile)
+    }
+}

--- a/resources/resources.qrc
+++ b/resources/resources.qrc
@@ -20,5 +20,6 @@
         <file>pages/widget_factory.qml</file>
         <file>themes/PhyTheme/PhyTheme.qml</file>
         <file>themes/PhyTheme/qmldir</file>
+        <file>pages/multimedia_qmlsink.qml</file>
     </qresource>
 </RCC>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,10 +7,12 @@
 #include <QQmlApplicationEngine>
 #include <QCommandLineParser>
 #include <QQmlContext>
+#include <QQuickWindow>
 #include <QSettings>
 #include <QFile>
 #include "device_info.hpp"
 #include "rauc.hpp"
+#include "multimedia_qmlsink.hpp"
 
 void writeDefaultSettings()
 {
@@ -69,13 +71,16 @@ int main(int argc, char *argv[])
     qmlRegisterSingletonType<DeviceInfo>("Phytec.DeviceInfo", 1, 0, "DeviceInfo",
                                          DeviceInfo::singletontypeProvider);
     qmlRegisterType<Rauc>("Phytec.Rauc", 1, 0, "Rauc");
+    MultimediaGST *multimediaGST = new MultimediaGST(&app, argc, argv);
 
     QQmlApplicationEngine engine;
     engine.addImportPath("qrc:///themes");
     engine.rootContext()->setContextProperty("raucHawkbitConfigPath",
                                              parser.value("rauc-hawkbit-config"));
     engine.rootContext()->setContextProperty("enabledPages", enabledPages);
+    engine.rootContext()->setContextProperty("multimediaGST", multimediaGST);
     engine.load(QUrl(QStringLiteral("qrc:///main.qml")));
+    multimediaGST->setRootObject(static_cast<QQuickWindow *> (engine.rootObjects().first()));
 
     return app.exec();
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,7 +12,10 @@
 #include <QFile>
 #include "device_info.hpp"
 #include "rauc.hpp"
+
+#ifdef QML_SINK
 #include "multimedia_qmlsink.hpp"
+#endif
 
 void writeDefaultSettings()
 {
@@ -71,16 +74,24 @@ int main(int argc, char *argv[])
     qmlRegisterSingletonType<DeviceInfo>("Phytec.DeviceInfo", 1, 0, "DeviceInfo",
                                          DeviceInfo::singletontypeProvider);
     qmlRegisterType<Rauc>("Phytec.Rauc", 1, 0, "Rauc");
-    MultimediaGST *multimediaGST = new MultimediaGST(&app, argc, argv);
 
     QQmlApplicationEngine engine;
     engine.addImportPath("qrc:///themes");
     engine.rootContext()->setContextProperty("raucHawkbitConfigPath",
                                              parser.value("rauc-hawkbit-config"));
     engine.rootContext()->setContextProperty("enabledPages", enabledPages);
+    engine.rootContext()->setContextProperty("multimediaPage", "multimedia.qml");
+#ifdef QML_SINK
+    MultimediaGST *multimediaGST = new MultimediaGST(&app, argc, argv);
+    engine.rootContext()->setContextProperty("multimediaPage", "multimedia_qmlsink.qml");
     engine.rootContext()->setContextProperty("multimediaGST", multimediaGST);
+#endif
+
     engine.load(QUrl(QStringLiteral("qrc:///main.qml")));
+
+#ifdef QML_SINK
     multimediaGST->setRootObject(static_cast<QQuickWindow *> (engine.rootObjects().first()));
+#endif
 
     return app.exec();
 }

--- a/src/multimedia_qmlsink.cpp
+++ b/src/multimedia_qmlsink.cpp
@@ -1,0 +1,264 @@
+#include "multimedia_qmlsink.hpp"
+#include <QDebug>
+#include <QQuickItem>
+#include <QQuickWindow>
+#include <QRunnable>
+#include <QString>
+#include <QTimer>
+#include <gst/gst.h>
+
+InitState::InitState (GstElement * pipeline)
+{
+    this->pipeline_ = pipeline ? static_cast<GstElement *> (gst_object_ref (pipeline)) : NULL;
+}
+
+InitState::~InitState ()
+{
+    if (this->pipeline_)
+        gst_object_unref (this->pipeline_);
+}
+
+void InitState::run ()
+{
+    if (this->pipeline_) {
+        // First set pipeline to PAUSED and wait for async state change
+        gst_element_set_state (this->pipeline_, GST_STATE_PAUSED);
+        gst_element_get_state(this->pipeline_, nullptr, nullptr, GST_CLOCK_TIME_NONE);
+
+        // Uncoment botom line for dumping the pipeline .dot file -> Useful for debugging.
+        // GST_DEBUG_BIN_TO_DOT_FILE(GST_BIN(this->pipeline_), GST_DEBUG_GRAPH_SHOW_ALL, "pipeline");
+
+        emit pipelineReady();
+    }
+}
+
+
+MultimediaGST::MultimediaGST(QObject *parent, int argc, char *argv[])
+    : QObject(parent)
+{
+    seek_timer = new QTimer(this);
+    connect(seek_timer, &QTimer::timeout, this, &MultimediaGST::getPosition);
+    seek_timer->setInterval(20);
+
+    gst_init (&argc, &argv);
+
+    // The plugin must be loaded before loading the qml file to register the
+    // GstGLVideoItem qml item.
+    gstData.video_sink = gst_element_factory_make ("qml6glsink", NULL);
+}
+
+void MultimediaGST::setupPipeline(QString file)
+{
+    gstData.pipeline = gst_pipeline_new ("pipeline");
+    gstData.source = gst_element_factory_make ("uridecodebin", "source");
+    gstData.video_convert = gst_element_factory_make ("videoconvert", "video-convert");
+    gstData.audio_convert = gst_element_factory_make ("audioconvert", "audio-convert");
+    gstData.audio_resample = gst_element_factory_make ("audioresample", "audio-resample");
+    gstData.glupload = gst_element_factory_make ("glupload", "glupload");
+    gstData.video_sink = gst_element_factory_make ("qml6glsink", "video-sink");
+    gstData.audio_sink = gst_element_factory_make ("autoaudiosink", "audio-sink");
+
+    // Set source file to be played.
+    g_object_set (gstData.source, "uri", file.toStdString().c_str(), NULL);
+
+    if (!gstData.pipeline || !gstData.source || !gstData.video_convert || !gstData.glupload
+        || !gstData.video_sink || !gstData.audio_convert || !gstData.audio_resample || !gstData.audio_sink) {
+        qFatal() << "Not all elements could be created.";
+    }
+
+    // Build the pipeline. Note that we are NOT linking the source at this
+    // point. We will do it later.
+    gst_bin_add_many (GST_BIN (gstData.pipeline), gstData.source, gstData.video_convert,
+                     gstData.glupload, gstData.video_sink,
+                     gstData.audio_convert, gstData.audio_resample, gstData.audio_sink, NULL);
+
+    // Link video part of pipeline
+    if (!gst_element_link_many (gstData.video_convert, gstData.glupload, gstData.video_sink, NULL)) {
+        gst_object_unref (gstData.pipeline);
+        qFatal() << "Elements in video pipeline could not be linked.";
+    }
+
+    // Link audio part of pipeline
+    if (!gst_element_link_many (gstData.audio_convert, gstData.audio_resample, gstData.audio_sink, NULL)) {
+        gst_object_unref (gstData.pipeline);
+        qFatal() << "Elements in audio pipeline could not be linked.";
+    }
+
+    // Register a calback for everytime a pad-added signal is emited.
+    g_signal_connect (gstData.source, "pad-added", G_CALLBACK (pad_added_handler),
+                     &gstData);
+}
+
+void MultimediaGST::cleanPipeline()
+{
+    if(!gstData.pipeline)
+        return;
+
+    seek_timer->stop();
+    gst_element_set_state (gstData.pipeline, GST_STATE_NULL);
+
+    // Unlinke all elements in pipeline.
+    gst_element_unlink(gstData.source, gstData.video_convert);
+    gst_element_unlink(gstData.video_convert, gstData.glupload);
+    gst_element_unlink(gstData.glupload, gstData.video_sink);
+    gst_element_unlink(gstData.source, gstData.audio_convert);
+    gst_element_unlink(gstData.audio_convert, gstData.audio_resample);
+    gst_element_unlink(gstData.audio_resample, gstData.audio_sink);
+    gst_object_unref (gstData.pipeline);
+}
+
+void MultimediaGST::setupNewPipeline(QString file)
+{
+    cleanPipeline();
+    setupPipeline(file);
+
+    QQuickItem *videoItem;
+    QQuickWindow *rootObject = m_rootObject;
+
+    // Find and set the videoItem on the sink
+    videoItem = rootObject->findChild<QQuickItem *> ("videoItem");
+    g_assert (videoItem);
+    g_object_set(gstData.video_sink, "widget", videoItem, NULL);
+
+    // Schedule render job for pipeline. This makes it possible to obtain video duration.
+    initState = new InitState (gstData.pipeline);
+    QObject::connect(initState, &InitState::pipelineReady, this, &MultimediaGST::pipelineReady);
+    rootObject->scheduleRenderJob (initState,
+                                  QQuickWindow::BeforeSynchronizingStage);
+}
+
+void MultimediaGST::pipelineReady()
+{
+    getDuration();
+    seek_timer->start();
+}
+
+// This function will be called by the pad-added signal
+void MultimediaGST::pad_added_handler (GstElement * src, GstPad * new_pad, CustomData *data)
+{
+    GstPad *video_sink_pad = gst_element_get_static_pad (data->video_convert, "sink");
+    GstPad *audio_sink_pad = gst_element_get_static_pad (data->audio_convert, "sink");
+    GstPadLinkReturn ret;
+    GstCaps *new_pad_caps = NULL;
+    GstStructure *new_pad_struct = NULL;
+    const gchar *new_pad_type = NULL;
+
+    // Return if both (audio & video) sub-pipelines are already linked
+    if (gst_pad_is_linked (video_sink_pad) && gst_pad_is_linked (audio_sink_pad))
+        goto exit;
+
+    // Check the new pad's type
+    new_pad_caps = gst_pad_get_current_caps (new_pad);
+    new_pad_struct = gst_caps_get_structure (new_pad_caps, 0);
+    new_pad_type = gst_structure_get_name (new_pad_struct);
+
+    if (g_str_has_prefix (new_pad_type, "video/x-raw")) {
+        // Attempt the link of video pads
+        ret = gst_pad_link (new_pad, video_sink_pad);
+        if (GST_PAD_LINK_FAILED (ret)) {
+            qWarning() << "Type is " << new_pad_type << "but link failed";
+        } else {
+            qDebug() << "Link succeeded (type "<< new_pad_type << ").";
+        }
+    } else if (g_str_has_prefix (new_pad_type, "audio/x-raw")) {
+        // Attempt the link of audio pads
+        ret = gst_pad_link (new_pad, audio_sink_pad);
+        if (GST_PAD_LINK_FAILED (ret)) {
+            qWarning() << "Type is " << new_pad_type << "but link failed";
+        } else {
+            qDebug() << "Link succeeded (type "<< new_pad_type << ").";
+        }
+    } else {
+        qDebug() << "It has type " << new_pad_type << "which is not raw video/audio. Ignoring.";
+    }
+
+exit:
+    // Unreference the new pad's caps, if we got them
+    if (new_pad_caps != NULL)
+        gst_caps_unref (new_pad_caps);
+
+    // Unreference the sink pad
+    gst_object_unref (video_sink_pad);
+    gst_object_unref (audio_sink_pad);
+}
+
+MultimediaGST::~MultimediaGST()
+{
+    gst_element_set_state (gstData.pipeline, GST_STATE_NULL);
+    gst_object_unref (gstData.pipeline);
+    gst_deinit();
+}
+
+void MultimediaGST::setRootObject(QQuickWindow * rootObject)
+{
+    m_rootObject = rootObject;
+}
+
+void MultimediaGST::play()
+{
+    gst_element_set_state (gstData.pipeline, GST_STATE_PLAYING);
+}
+
+void MultimediaGST::pause()
+{
+    gst_element_set_state (gstData.pipeline, GST_STATE_PAUSED);
+}
+
+void MultimediaGST::seek(gint64 val)
+{
+    GstState state;
+    gst_element_get_state(gstData.pipeline, &state, nullptr, GST_CLOCK_TIME_NONE);
+
+    // First set pipeline to PAUSED and wait for async state change
+    gst_element_set_state (gstData.pipeline, GST_STATE_PAUSED);
+    gst_element_get_state(gstData.pipeline, nullptr, nullptr, GST_CLOCK_TIME_NONE);
+    if (!gst_element_seek (gstData.pipeline, 1.0, GST_FORMAT_TIME, GST_SEEK_FLAG_FLUSH, GST_SEEK_TYPE_SET, val * GST_MSECOND, GST_SEEK_TYPE_NONE, -1))
+        qWarning() << "Seek failed!";
+
+    gst_element_get_state(gstData.pipeline, nullptr, nullptr, GST_CLOCK_TIME_NONE);
+
+    // Put the pipeline in the same state that it was in before the seek
+    if (state > 3)
+        gst_element_set_state (gstData.pipeline, GST_STATE_PLAYING);
+    else
+        gst_element_set_state (gstData.pipeline, GST_STATE_PAUSED);
+
+    // Emit position in ms
+    emit positionChanged(val);
+}
+
+void MultimediaGST::getDuration()
+{
+    gint64 len;
+    if (!gst_element_query_duration (gstData.pipeline, GST_FORMAT_TIME, &len))
+    {
+        qWarning() << "seek duration failed";
+        return;
+    }
+
+    // Emit duration in ms
+    emit durationChanged(len/GST_MSECOND);
+}
+
+void MultimediaGST::getPosition()
+{
+    gint64 pos;
+    if (!gst_element_query_position (gstData.pipeline, GST_FORMAT_TIME, &pos))
+    {
+        qWarning() << "seek position failed";
+        return;
+    }
+
+    // Emit position in ms
+    emit positionChanged(pos/GST_MSECOND);
+}
+
+void MultimediaGST::positionStop()
+{
+    seek_timer->stop();
+}
+
+void MultimediaGST::positionStart()
+{
+    seek_timer->start();
+}

--- a/src/multimedia_qmlsink.hpp
+++ b/src/multimedia_qmlsink.hpp
@@ -1,0 +1,72 @@
+#ifndef MULTIMEDIA_GST_HPP
+#define MULTIMEDIA_GST_HPP
+
+#include <QQuickItem>
+#include <QRunnable>
+#include <QObject>
+#include <gst/gst.h>
+
+struct CustomData
+{
+    GstElement *pipeline;
+    GstElement *source;
+    GstElement *video_convert;
+    GstElement *glupload;
+    GstElement *video_sink;
+    GstElement *audio_convert;
+    GstElement *audio_resample;
+    GstElement *audio_sink;
+};
+
+class InitState : public QObject, public QRunnable
+{
+    Q_OBJECT
+public:
+    InitState(GstElement *);
+    ~InitState();
+
+    void run ();
+
+private:
+    GstElement * pipeline_;
+
+signals:
+    void pipelineReady();
+};
+
+class MultimediaGST : public QObject
+{
+    Q_OBJECT
+
+private:
+    QQuickWindow *m_rootObject;
+    CustomData gstData;
+    InitState *initState;
+    QTimer *seek_timer;
+    /* Handler for the pad-added signal */
+    static void pad_added_handler (GstElement * src, GstPad * pad, CustomData * data);
+    void setupPipeline(QString file);
+    void cleanPipeline();
+    void getDuration();
+    void getPosition();
+    void pipelineReady();
+
+public:
+    explicit MultimediaGST(QObject *parent = nullptr, int argc = 0, char *argv[] = nullptr);
+    ~MultimediaGST();
+
+public slots:
+    void setupNewPipeline(QString file);
+    void play();
+    void pause();
+    void seek(gint64 val);
+    void positionStop();
+    void positionStart();
+    void setRootObject(QQuickWindow * rootObject);
+
+signals:
+    void durationChanged(qint64 len);
+    void positionChanged(qint64 cur);
+};
+
+#endif // MULTIMEDIA_GST_HPP


### PR DESCRIPTION
Hi,

added additional Multimedia page where "qml6glsink" can be used as Gstreamer video sink.
This increases the performance of multimedia page which is regularly disabled.

For now, this was only tested with i.MX8MP Pollux, where we can now play 1080p videos without a problem. (Before, reduced framerate could already be observed with 720p videos.)

Future work could include specifying gstreamer pipeline in config file.