### PR TITLE
fix fileURL

### DIFF
--- a/resources/controls/PhyFileDialog.qml
+++ b/resources/controls/PhyFileDialog.qml
@@ -111,7 +111,7 @@ Rectangle {
                         folderListModel.folder = dialog.currentFile
                         listView.currentIndex = -1
                     } else {
-                        dialog.currentFile = fileURL
+                        dialog.currentFile = fileUrl
                     }
                 }
             }

--- a/resources/pages/image_viewer.qml
+++ b/resources/pages/image_viewer.qml
@@ -53,7 +53,7 @@ Page {
                 MouseArea {
                     anchors.fill: parent
                     onClicked: {
-                        detailedImageView.filename = fileURL
+                        detailedImageView.filename = fileUrl
                         detailedImageView.title = fileName
                         detailedImageView.visible = true
                         gridViewGallery.visible = false
@@ -65,7 +65,7 @@ Page {
                     anchors.margins: PhyTheme.marginRegular
 
                     Image {
-                        source: fileURL
+                        source: fileUrl
                         fillMode: Image.PreserveAspectCrop
                         asynchronous: true
                         Layout.fillHeight: true


### PR DESCRIPTION
fileURL is deprecated since qt version 5.15 and has been removed for qt version 6.10. fileUrl should be used instead. In some places the new syntax is already used. Replace it for the missing places.

Link: https://doc.qt.io/qt-6.8/qml-qt-labs-folderlistmodel-folderlistmodel.html